### PR TITLE
Replace pageX and pageY with clientX and clientY to fix scroll issue

### DIFF
--- a/src/lib/components/ColorPicker/Area/Alpha/script.js
+++ b/src/lib/components/ColorPicker/Area/Alpha/script.js
@@ -48,7 +48,7 @@ export default {
     methods: {
         mouseDownHandler(event) {
             const elementX = event.currentTarget.getBoundingClientRect().x;
-            const startX = event.pageX;
+            const startX = event.clientX;
             const positionX = startX - elementX;
 
             this.updateColor({ alpha: getAlpha(positionX, this.width) }, 'onStartChange');
@@ -61,7 +61,7 @@ export default {
         },
 
         changeObjectPositions(event, { startX, positionX }) {
-            const moveX = event.pageX - startX;
+            const moveX = event.clientX - startX;
             positionX += moveX;
 
             const alpha = getAlpha(positionX, this.width);
@@ -69,7 +69,7 @@ export default {
             return {
                 positions: {
                     positionX,
-                    startX: event.pageX,
+                    startX: event.clientX,
                 },
                 alpha,
             };

--- a/src/lib/components/ColorPicker/Area/GradientPoints/GradientPoint/script.js
+++ b/src/lib/components/ColorPicker/Area/GradientPoints/GradientPoint/script.js
@@ -39,8 +39,8 @@ export default {
         mouseDownHandler(event) {
             this.changeActivePointIndex(this.index);
 
-            const startX = event.pageX;
-            const startY = event.pageY;
+            const startX = event.clientX;
+            const startY = event.clientY;
             const offsetX = startX - this.positions.x;
 
             this.updateGradientLeft(this.point.left, this.index, 'onStartChange');
@@ -54,7 +54,7 @@ export default {
         },
 
         changeObjectPositions(event, { startX, offsetX }) {
-            const moveX = event.pageX - startX;
+            const moveX = event.clientX - startX;
             offsetX += moveX;
             // update point percent
             const left = updateGradientActivePercent(offsetX, this.width);
@@ -62,7 +62,7 @@ export default {
             return {
                 positions: {
                     offsetX,
-                    startX: event.pageX,
+                    startX: event.clientX,
                 },
                 left,
             };

--- a/src/lib/components/ColorPicker/Area/GradientPoints/script.js
+++ b/src/lib/components/ColorPicker/Area/GradientPoints/script.js
@@ -47,7 +47,7 @@ export default {
 
     methods: {
         pointsContainerClick(event) {
-            const left = updateGradientActivePercent(event.pageX - this.positions.x, this.width);
+            const left = updateGradientActivePercent(event.clientX - this.positions.x, this.width);
 
             this.addPoint(left);
         },

--- a/src/lib/components/ColorPicker/Area/Hue/script.js
+++ b/src/lib/components/ColorPicker/Area/Hue/script.js
@@ -43,7 +43,7 @@ export default {
     methods: {
         mouseDownHandler(event) {
             const elementX = event.currentTarget.getBoundingClientRect().x;
-            const startX = event.pageX;
+            const startX = event.clientX;
             const positionX = startX - elementX;
 
             const color = getHue(positionX, this.width, this.saturation, this.value);
@@ -57,7 +57,7 @@ export default {
         },
 
         changeObjectPositions(event, { startX, positionX }) {
-            const moveX = event.pageX - startX;
+            const moveX = event.clientX - startX;
             positionX += moveX;
 
             // update value and saturation
@@ -67,7 +67,7 @@ export default {
             return {
                 positions: {
                     positionX,
-                    startX: event.pageX,
+                    startX: event.clientX,
                 },
                 color,
             };

--- a/src/lib/components/ColorPicker/Area/Picker/script.js
+++ b/src/lib/components/ColorPicker/Area/Picker/script.js
@@ -61,8 +61,8 @@ export default {
     methods: {
         mouseDownHandler(event) {
             const { x: elementX, y: elementY } = this.$refs.pickerAreaRef.getBoundingClientRect();
-            const startX = event.pageX;
-            const startY = event.pageY;
+            const startX = event.clientX;
+            const startY = event.clientY;
             const positionX = startX - elementX;
             const positionY = startY - elementY;
 
@@ -79,8 +79,8 @@ export default {
         },
 
         changeObjectPositions(event, { startX, startY, positionX, positionY }) {
-            const moveX = event.pageX - startX;
-            const moveY = event.pageY - startY;
+            const moveX = event.clientX - startX;
+            const moveY = event.clientY - startY;
             positionX += moveX;
             positionY += moveY;
 
@@ -90,8 +90,8 @@ export default {
                 positions: {
                     positionX,
                     positionY,
-                    startX: event.pageX,
-                    startY: event.pageY,
+                    startX: event.clientX,
+                    startY: event.clientY,
                 },
                 color,
             };


### PR DESCRIPTION
Fixing issue #11 which caused a bug that whenever a user scrolls the color picker position got messed up. 

The reason for this issue was pageX and pageY being used instead of clientX and clientY. You can read more about it here: https://stackoverflow.com/questions/6073505/what-is-the-difference-between-screenx-y-clientx-y-and-pagex-y